### PR TITLE
Tell git to ignore the Python setuptools build/dist/metadata dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/build/
+/dist/
+/git_remote_hg.egg-info/


### PR DESCRIPTION
This helps ensure these don't get committed by accident and
helps prevent git interacting with them in other ways.